### PR TITLE
Issue #3: Cache Dependencies Framework

### DIFF
--- a/src/fullon_cache_api/dependencies/__init__.py
+++ b/src/fullon_cache_api/dependencies/__init__.py
@@ -1,1 +1,166 @@
-# FastAPI dependency injection for cache sessions
+"""
+FastAPI dependency injection for cache sessions.
+
+Provides lightweight, read-only cache session dependencies that integrate with
+FastAPI's `Depends(...)` pattern. Each dependency opens a cache session using
+fullon_cache and ensures proper async cleanup.
+
+Design constraints:
+- Read-only usage only; no mutating operations.
+- Async context management for clean resource handling.
+- Degrades gracefully when `fullon_cache` is unavailable.
+"""
+
+from collections.abc import AsyncGenerator
+from typing import Any, Optional, TYPE_CHECKING
+
+from fullon_log import get_component_logger  # type: ignore
+
+from ..exceptions import CacheServiceUnavailableError
+
+logger = get_component_logger("fullon.api.cache.dependencies")
+
+if TYPE_CHECKING:  # type hints without importing at runtime
+    from fullon_cache import (  # pragma: no cover - type checking only
+        AccountCache as _AccountCache,
+        BotCache as _BotCache,
+        OHLCVCache as _OHLCVCache,
+        OrdersCache as _OrdersCache,
+        TickCache as _TickCache,
+        TradesCache as _TradesCache,
+    )
+
+
+def _import_caches() -> dict[str, Optional[type]]:
+    """Attempt to import cache classes from fullon_cache.
+
+    Returns a dict of cache class references or None when unavailable.
+    """
+    try:  # defer import to runtime to avoid hard dependency during import
+        from fullon_cache import (  # type: ignore
+            AccountCache,
+            BotCache,
+            OHLCVCache,
+            OrdersCache,
+            TickCache,
+            TradesCache,
+        )
+
+        return {
+            "TickCache": TickCache,
+            "OrdersCache": OrdersCache,
+            "BotCache": BotCache,
+            "TradesCache": TradesCache,
+            "AccountCache": AccountCache,
+            "OHLCVCache": OHLCVCache,
+        }
+    except Exception as exc:  # pragma: no cover - environment dependent
+        logger.warning(
+            "fullon_cache import failed; dependencies will raise on use",
+            error=str(exc),
+        )
+        return {
+            "TickCache": None,
+            "OrdersCache": None,
+            "BotCache": None,
+            "TradesCache": None,
+            "AccountCache": None,
+            "OHLCVCache": None,
+        }
+
+
+_caches = _import_caches()
+
+
+async def get_tick_cache() -> AsyncGenerator["_TickCache" | Any, None]:
+    tick_cls = _caches.get("TickCache")
+    if tick_cls is None:
+        raise CacheServiceUnavailableError(
+            "TickCache unavailable: install/configure fullon_cache"
+        )
+    logger.info("Opening TickCache session")
+    async with tick_cls() as cache:  # type: ignore[call-arg]
+        try:
+            yield cache
+        finally:
+            logger.info("Closed TickCache session")
+
+
+async def get_orders_cache() -> AsyncGenerator["_OrdersCache" | Any, None]:
+    orders_cls = _caches.get("OrdersCache")
+    if orders_cls is None:
+        raise CacheServiceUnavailableError(
+            "OrdersCache unavailable: install/configure fullon_cache"
+        )
+    logger.info("Opening OrdersCache session")
+    async with orders_cls() as cache:  # type: ignore[call-arg]
+        try:
+            yield cache
+        finally:
+            logger.info("Closed OrdersCache session")
+
+
+async def get_bot_cache() -> AsyncGenerator["_BotCache" | Any, None]:
+    bot_cls = _caches.get("BotCache")
+    if bot_cls is None:
+        raise CacheServiceUnavailableError(
+            "BotCache unavailable: install/configure fullon_cache"
+        )
+    logger.info("Opening BotCache session")
+    async with bot_cls() as cache:  # type: ignore[call-arg]
+        try:
+            yield cache
+        finally:
+            logger.info("Closed BotCache session")
+
+
+async def get_trades_cache() -> AsyncGenerator["_TradesCache" | Any, None]:
+    trades_cls = _caches.get("TradesCache")
+    if trades_cls is None:
+        raise CacheServiceUnavailableError(
+            "TradesCache unavailable: install/configure fullon_cache"
+        )
+    logger.info("Opening TradesCache session")
+    async with trades_cls() as cache:  # type: ignore[call-arg]
+        try:
+            yield cache
+        finally:
+            logger.info("Closed TradesCache session")
+
+
+async def get_account_cache() -> AsyncGenerator["_AccountCache" | Any, None]:
+    account_cls = _caches.get("AccountCache")
+    if account_cls is None:
+        raise CacheServiceUnavailableError(
+            "AccountCache unavailable: install/configure fullon_cache"
+        )
+    logger.info("Opening AccountCache session")
+    async with account_cls() as cache:  # type: ignore[call-arg]
+        try:
+            yield cache
+        finally:
+            logger.info("Closed AccountCache session")
+
+
+async def get_ohlcv_cache() -> AsyncGenerator["_OHLCVCache" | Any, None]:
+    ohlcv_cls = _caches.get("OHLCVCache")
+    if ohlcv_cls is None:
+        raise CacheServiceUnavailableError(
+            "OHLCVCache unavailable: install/configure fullon_cache"
+        )
+    logger.info("Opening OHLCVCache session")
+    async with ohlcv_cls() as cache:  # type: ignore[call-arg]
+        try:
+            yield cache
+        finally:
+            logger.info("Closed OHLCVCache session")
+
+
+__all__ = [
+    "get_tick_cache",
+    "get_orders_cache",
+    "get_bot_cache",
+    "get_trades_cache",
+    "get_account_cache",
+    "get_ohlcv_cache",
+]


### PR DESCRIPTION
Implements FastAPI DI providers for read-only fullon_cache sessions.\n\n- Adds async generator dependencies: tick, orders, bot, trades, account, ohlcv\n- Uses fullon_log for open/close logging\n- Defers imports; fails fast with CacheServiceUnavailableError when fullon_cache unavailable\n- Read-only by design; async context mgmt for clean lifecycle\n\nCloses #3.