### PR TITLE
refactor: enforce fullon_log (no fallback)

### DIFF
--- a/src/fullon_cache_api/base.py
+++ b/src/fullon_cache_api/base.py
@@ -10,39 +10,7 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 from fastapi import WebSocket
-
-
-def _safe_get_component_logger(name: str):
-    try:  # Avoid fullon_log multiprocessing init in restricted envs
-        from fullon_log import get_component_logger as _gcl  # type: ignore
-
-        return _gcl(name)
-    except Exception:  # pragma: no cover - environment dependent
-        import logging
-
-        class _KVLLoggerAdapter:
-            def __init__(self, base):
-                self._base = base
-
-            def _fmt(self, msg: str, **kwargs):
-                if kwargs:
-                    kv = " ".join(f"{k}={v}" for k, v in kwargs.items())
-                    return f"{msg} | {kv}"
-                return msg
-
-            def debug(self, msg, *args, **kwargs):
-                self._base.debug(self._fmt(msg, **kwargs), *args)
-
-            def info(self, msg, *args, **kwargs):
-                self._base.info(self._fmt(msg, **kwargs), *args)
-
-            def warning(self, msg, *args, **kwargs):
-                self._base.warning(self._fmt(msg, **kwargs), *args)
-
-            def error(self, msg, *args, **kwargs):
-                self._base.error(self._fmt(msg, **kwargs), *args)
-
-        return _KVLLoggerAdapter(logging.getLogger(name))
+from fullon_log import get_component_logger  # type: ignore
 
 
 class BaseFastAPIWebSocketHandler(ABC):
@@ -50,8 +18,8 @@ class BaseFastAPIWebSocketHandler(ABC):
 
     def __init__(self) -> None:
         """Initialize WebSocket handler with logging."""
-        # CRITICAL: Use fullon_log component logger (fallback to stdlib logger)
-        self.logger = _safe_get_component_logger("fullon.api.cache.websocket")
+        # CRITICAL: Use fullon_log component logger
+        self.logger = get_component_logger("fullon.api.cache.websocket")
 
     @abstractmethod
     async def handle_message(
@@ -92,8 +60,8 @@ class BaseFastAPIWebSocketStream(ABC):
 
     def __init__(self) -> None:
         """Initialize WebSocket stream handler with logging."""
-        # CRITICAL: Use fullon_log component logger (fallback to stdlib logger)
-        self.logger = _safe_get_component_logger("fullon.api.cache.websocket.stream")
+        # CRITICAL: Use fullon_log component logger
+        self.logger = get_component_logger("fullon.api.cache.websocket.stream")
 
     @abstractmethod
     async def stream_updates(
@@ -119,8 +87,8 @@ class CacheHealthChecker:
 
     def __init__(self) -> None:
         """Initialize health checker with logging."""
-        # CRITICAL: Use fullon_log component logger (fallback to stdlib logger)
-        self.logger = _safe_get_component_logger("fullon.api.cache.health")
+        # CRITICAL: Use fullon_log component logger
+        self.logger = get_component_logger("fullon.api.cache.health")
 
     async def check_websocket_connectivity(self) -> dict[str, Any]:
         """Check FastAPI WebSocket server connectivity.

--- a/src/fullon_cache_api/handlers/account_handler.py
+++ b/src/fullon_cache_api/handlers/account_handler.py
@@ -20,42 +20,10 @@ import time
 from typing import Any
 
 from fastapi import WebSocket, WebSocketDisconnect
+from fullon_log import get_component_logger  # type: ignore
 
 
-def _safe_get_component_logger(name: str):
-    try:
-        from fullon_log import get_component_logger as _gcl  # type: ignore
-
-        return _gcl(name)
-    except Exception:  # pragma: no cover - environment dependent
-        import logging
-
-        class _KVLLoggerAdapter:
-            def __init__(self, base):
-                self._base = base
-
-            def _fmt(self, msg: str, **kwargs):
-                if kwargs:
-                    kv = " ".join(f"{k}={v}" for k, v in kwargs.items())
-                    return f"{msg} | {kv}"
-                return msg
-
-            def debug(self, msg, *args, **kwargs):
-                self._base.debug(self._fmt(msg, **kwargs), *args)
-
-            def info(self, msg, *args, **kwargs):
-                self._base.info(self._fmt(msg, **kwargs), *args)
-
-            def warning(self, msg, *args, **kwargs):
-                self._base.warning(self._fmt(msg, **kwargs), *args)
-
-            def error(self, msg, *args, **kwargs):
-                self._base.error(self._fmt(msg, **kwargs), *args)
-
-        return _KVLLoggerAdapter(logging.getLogger(name))
-
-
-logger = _safe_get_component_logger("fullon.api.cache.accounts")
+logger = get_component_logger("fullon.api.cache.accounts")
 
 
 class AccountWebSocketHandler:

--- a/src/fullon_cache_api/handlers/ticker_handler.py
+++ b/src/fullon_cache_api/handlers/ticker_handler.py
@@ -19,42 +19,10 @@ import json
 from typing import Any
 
 from fastapi import WebSocket, WebSocketDisconnect
+from fullon_log import get_component_logger  # type: ignore
 
 
-def _safe_get_component_logger(name: str):
-    try:
-        from fullon_log import get_component_logger as _gcl  # type: ignore
-
-        return _gcl(name)
-    except Exception:  # pragma: no cover - environment dependent
-        import logging
-
-        class _KVLLoggerAdapter:
-            def __init__(self, base):
-                self._base = base
-
-            def _fmt(self, msg: str, **kwargs):
-                if kwargs:
-                    kv = " ".join(f"{k}={v}" for k, v in kwargs.items())
-                    return f"{msg} | {kv}"
-                return msg
-
-            def debug(self, msg, *args, **kwargs):
-                self._base.debug(self._fmt(msg, **kwargs), *args)
-
-            def info(self, msg, *args, **kwargs):
-                self._base.info(self._fmt(msg, **kwargs), *args)
-
-            def warning(self, msg, *args, **kwargs):
-                self._base.warning(self._fmt(msg, **kwargs), *args)
-
-            def error(self, msg, *args, **kwargs):
-                self._base.error(self._fmt(msg, **kwargs), *args)
-
-        return _KVLLoggerAdapter(logging.getLogger(name))
-
-
-logger = _safe_get_component_logger("fullon.api.cache.tickers")
+logger = get_component_logger("fullon.api.cache.tickers")
 
 
 class TickerWebSocketHandler:

--- a/src/fullon_cache_api/main.py
+++ b/src/fullon_cache_api/main.py
@@ -8,44 +8,14 @@ No REST endpoints are exposed; use WebSocket for all interactions.
 from fastapi import FastAPI
 
 
-def _safe_get_component_logger(name: str):
-    try:
-        from fullon_log import get_component_logger as _gcl  # type: ignore
-
-        return _gcl(name)
-    except Exception:  # pragma: no cover - environment dependent
-        import logging
-
-        class _KVLLoggerAdapter:
-            def __init__(self, base):
-                self._base = base
-
-            def _fmt(self, msg: str, **kwargs):
-                if kwargs:
-                    kv = " ".join(f"{k}={v}" for k, v in kwargs.items())
-                    return f"{msg} | {kv}"
-                return msg
-
-            def debug(self, msg, *args, **kwargs):
-                self._base.debug(self._fmt(msg, **kwargs), *args)
-
-            def info(self, msg, *args, **kwargs):
-                self._base.info(self._fmt(msg, **kwargs), *args)
-
-            def warning(self, msg, *args, **kwargs):
-                self._base.warning(self._fmt(msg, **kwargs), *args)
-
-            def error(self, msg, *args, **kwargs):
-                self._base.error(self._fmt(msg, **kwargs), *args)
-
-        return _KVLLoggerAdapter(logging.getLogger(name))
+from fullon_log import get_component_logger  # type: ignore
 
 
 from .routers.accounts import router as accounts_router
 from .routers.tickers import router as tickers_router
 from .routers.websocket import router as ws_router
 
-logger = _safe_get_component_logger("fullon.api.cache.app")
+logger = get_component_logger("fullon.api.cache.app")
 
 
 def create_app() -> FastAPI:

--- a/src/fullon_cache_api/models/data.py
+++ b/src/fullon_cache_api/models/data.py
@@ -8,45 +8,13 @@ optimized for FastAPI WebSocket JSON serialization with fullon_log integration.
 import time
 from decimal import Decimal
 from typing import Any
-
-
-def _safe_get_component_logger(name: str):
-    try:
-        from fullon_log import get_component_logger as _gcl  # type: ignore
-
-        return _gcl(name)
-    except Exception:  # pragma: no cover - environment dependent
-        import logging
-
-        class _KVLLoggerAdapter:
-            def __init__(self, base):
-                self._base = base
-
-            def _fmt(self, msg: str, **kwargs):
-                if kwargs:
-                    kv = " ".join(f"{k}={v}" for k, v in kwargs.items())
-                    return f"{msg} | {kv}"
-                return msg
-
-            def debug(self, msg, *args, **kwargs):
-                self._base.debug(self._fmt(msg, **kwargs), *args)
-
-            def info(self, msg, *args, **kwargs):
-                self._base.info(self._fmt(msg, **kwargs), *args)
-
-            def warning(self, msg, *args, **kwargs):
-                self._base.warning(self._fmt(msg, **kwargs), *args)
-
-            def error(self, msg, *args, **kwargs):
-                self._base.error(self._fmt(msg, **kwargs), *args)
-
-        return _KVLLoggerAdapter(logging.getLogger(name))
+from fullon_log import get_component_logger  # type: ignore
 
 
 from pydantic import BaseModel, Field, validator
 
 # Initialize component logger for data models
-logger = _safe_get_component_logger("fullon.api.cache.models.data")
+logger = get_component_logger("fullon.api.cache.models.data")
 
 
 class TickerData(BaseModel):

--- a/src/fullon_cache_api/models/messages.py
+++ b/src/fullon_cache_api/models/messages.py
@@ -12,45 +12,13 @@ real-time messaging patterns.
 import time
 import uuid
 from typing import Any
-
-
-def _safe_get_component_logger(name: str):
-    try:
-        from fullon_log import get_component_logger as _gcl  # type: ignore
-
-        return _gcl(name)
-    except Exception:  # pragma: no cover - environment dependent
-        import logging
-
-        class _KVLLoggerAdapter:
-            def __init__(self, base):
-                self._base = base
-
-            def _fmt(self, msg: str, **kwargs):
-                if kwargs:
-                    kv = " ".join(f"{k}={v}" for k, v in kwargs.items())
-                    return f"{msg} | {kv}"
-                return msg
-
-            def debug(self, msg, *args, **kwargs):
-                self._base.debug(self._fmt(msg, **kwargs), *args)
-
-            def info(self, msg, *args, **kwargs):
-                self._base.info(self._fmt(msg, **kwargs), *args)
-
-            def warning(self, msg, *args, **kwargs):
-                self._base.warning(self._fmt(msg, **kwargs), *args)
-
-            def error(self, msg, *args, **kwargs):
-                self._base.error(self._fmt(msg, **kwargs), *args)
-
-        return _KVLLoggerAdapter(logging.getLogger(name))
+from fullon_log import get_component_logger  # type: ignore
 
 
 from pydantic import BaseModel, Field, validator
 
 # Initialize component logger for message models
-logger = _safe_get_component_logger("fullon.api.cache.models.messages")
+logger = get_component_logger("fullon.api.cache.models.messages")
 
 # Define allowed operations for FastAPI WebSocket validation
 ALLOWED_OPERATIONS: set[str] = {

--- a/src/fullon_cache_api/routers/websocket.py
+++ b/src/fullon_cache_api/routers/websocket.py
@@ -14,39 +14,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
-
-
-def _safe_get_component_logger(name: str):
-    try:
-        from fullon_log import get_component_logger as _gcl  # type: ignore
-
-        return _gcl(name)
-    except Exception:  # pragma: no cover - environment dependent
-        import logging
-
-        class _KVLLoggerAdapter:
-            def __init__(self, base):
-                self._base = base
-
-            def _fmt(self, msg: str, **kwargs):
-                if kwargs:
-                    kv = " ".join(f"{k}={v}" for k, v in kwargs.items())
-                    return f"{msg} | {kv}"
-                return msg
-
-            def debug(self, msg, *args, **kwargs):
-                self._base.debug(self._fmt(msg, **kwargs), *args)
-
-            def info(self, msg, *args, **kwargs):
-                self._base.info(self._fmt(msg, **kwargs), *args)
-
-            def warning(self, msg, *args, **kwargs):
-                self._base.warning(self._fmt(msg, **kwargs), *args)
-
-            def error(self, msg, *args, **kwargs):
-                self._base.error(self._fmt(msg, **kwargs), *args)
-
-        return _KVLLoggerAdapter(logging.getLogger(name))
+from fullon_log import get_component_logger  # type: ignore
 
 
 from ..base import CacheHealthChecker
@@ -57,7 +25,7 @@ from ..models import (
     create_success_response,
 )
 
-logger = _safe_get_component_logger("fullon.api.cache.websocket.gateway")
+logger = get_component_logger("fullon.api.cache.websocket.gateway")
 
 router = APIRouter()
 


### PR DESCRIPTION
Per owner directive, remove any stdlib logging fallback and require fullon_log across the codebase.\n\n- Base, models, handlers, routers, main now import get_component_logger directly.\n- No try/except wrappers remain.\n\nNote: In restricted sandboxes this may fail due to multiprocessing in fullon_log; acceptable for production where fullon_log is present.