### PR TITLE
feat: Orders WebSocket handler + real Redis tests (closes #7)

### DIFF
--- a/examples/orders_websocket_client.py
+++ b/examples/orders_websocket_client.py
@@ -1,0 +1,45 @@
+"""Minimal example client for Orders WebSocket API.
+
+Usage:
+    poetry run python examples/orders_websocket_client.py
+"""
+
+import asyncio
+import json
+
+import websockets
+
+
+async def main() -> None:
+    uri = "ws://127.0.0.1:8000/ws/orders/example"
+    async with websockets.connect(uri) as ws:
+        # Query queue length (binance)
+        await ws.send(
+            json.dumps(
+                {
+                    "action": "get_queue_length",
+                    "request_id": "ql1",
+                    "params": {"exchange": "binance"},
+                }
+            )
+        )
+        print("queue length:", await ws.recv())
+
+        # Start stream
+        await ws.send(
+            json.dumps(
+                {
+                    "action": "stream_order_queue",
+                    "request_id": "s1",
+                    "params": {"exchange": "binance"},
+                }
+            )
+        )
+        # Print a few updates
+        for _ in range(3):
+            print("update:", await ws.recv())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/src/fullon_cache_api/handlers/order_handler.py
+++ b/src/fullon_cache_api/handlers/order_handler.py
@@ -1,0 +1,327 @@
+"""
+Orders WebSocket handler implementing read-only order status and queue operations.
+
+Implements:
+- get_order_status: fetch a single order status snapshot
+- get_queue_length: current number of orders for an exchange (proxy via cache)
+- stream_order_queue: real-time queue length updates (async, no callbacks)
+
+Design constraints:
+- Read-only operations only
+- Uses fullon_log for structured logging
+- Uses fullon_cache OrdersCache sessions with async context mgmt
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+
+from fastapi import WebSocket, WebSocketDisconnect
+from fullon_log import get_component_logger  # type: ignore
+
+
+logger = get_component_logger("fullon.api.cache.orders")
+
+
+class OrdersWebSocketHandler:
+    def __init__(self) -> None:
+        self.active_connections: dict[str, WebSocket] = {}
+        self.streaming_tasks: dict[str, asyncio.Task[Any]] = {}
+
+    async def handle_connection(self, websocket: WebSocket, connection_id: str) -> None:
+        await websocket.accept()
+        self.active_connections[connection_id] = websocket
+        logger.info(
+            "Orders WebSocket connected", connection_id=connection_id, handler="orders"
+        )
+
+        try:
+            while True:
+                message = await websocket.receive_text()
+                await self.route_order_message(websocket, message, connection_id)
+        except WebSocketDisconnect:
+            logger.info(
+                "Orders WebSocket disconnected",
+                connection_id=connection_id,
+                handler="orders",
+            )
+        finally:
+            await self.cleanup_connection(connection_id)
+
+    async def route_order_message(
+        self, websocket: WebSocket, message: str, connection_id: str
+    ) -> None:
+        try:
+            data = json.loads(message)
+        except json.JSONDecodeError:
+            await self.send_error(
+                websocket, None, "MALFORMED_MESSAGE", "Malformed JSON message"
+            )
+            return
+
+        action = data.get("action")
+        request_id = data.get("request_id")
+        params = data.get("params", {}) or {}
+
+        if action == "get_order_status":
+            await self.handle_get_order_status(
+                websocket, request_id, params, connection_id
+            )
+        elif action == "get_queue_length":
+            await self.handle_get_queue_length(websocket, request_id, params, connection_id)
+        elif action == "stream_order_queue":
+            await self.handle_stream_order_queue(
+                websocket, request_id, params, connection_id
+            )
+        else:
+            await self.send_error(
+                websocket,
+                request_id,
+                "INVALID_OPERATION",
+                f"Operation '{action}' not implemented",
+            )
+
+    async def send_error(
+        self, websocket: WebSocket, request_id: str | None, code: str, message: str
+    ) -> None:
+        payload = {
+            "request_id": request_id,
+            "success": False,
+            "error_code": code,
+            "error": message,
+        }
+        await websocket.send_text(json.dumps(payload))
+
+    async def handle_get_order_status(
+        self,
+        websocket: WebSocket,
+        request_id: str,
+        params: dict[str, Any],
+        connection_id: str,
+    ) -> None:
+        order_id = params.get("order_id")
+        exchange = params.get("exchange")
+
+        if not order_id or not exchange:
+            await self.send_error(
+                websocket,
+                request_id,
+                "INVALID_PARAMS",
+                "exchange and order_id parameters required",
+            )
+            return
+
+        logger.info(
+            "Get order status started",
+            exchange=exchange,
+            order_id=order_id,
+            request_id=request_id,
+            connection_id=connection_id,
+        )
+
+        try:
+            # Lazy import to avoid hard dependency at import time
+            from fullon_cache import OrdersCache  # type: ignore
+
+            async with OrdersCache() as cache:  # type: ignore[call-arg]
+                order = await cache.get_order_status(str(exchange), str(order_id))
+
+            if order:
+                volume = float(getattr(order, "volume", 0.0))
+                final_volume = getattr(order, "final_volume", None)
+                try:
+                    filled = float(final_volume) if final_volume is not None else 0.0
+                except Exception:
+                    filled = 0.0
+                remaining = max(volume - filled, 0.0)
+
+                # Normalize timestamp to float seconds when possible
+                ts_val = getattr(order, "timestamp", None)
+                if isinstance(ts_val, (int, float)):
+                    ts = float(ts_val)
+                else:
+                    try:
+                        # datetime -> seconds
+                        ts = float(getattr(ts_val, "timestamp", lambda: 0.0)())
+                    except Exception:
+                        ts = time.time()
+
+                result = {
+                    "order_id": getattr(order, "ex_order_id", str(order_id)),
+                    "symbol": getattr(order, "symbol", None),
+                    "exchange": str(exchange),
+                    "side": getattr(order, "side", None),
+                    "amount": volume,
+                    "price": float(getattr(order, "price", 0.0)),
+                    "filled": filled,
+                    "remaining": remaining,
+                    "status": getattr(order, "status", None),
+                    "order_type": getattr(order, "order_type", None),
+                    "timestamp": ts,
+                    "last_update": ts,
+                }
+                response = {
+                    "request_id": request_id,
+                    "action": "get_order_status",
+                    "success": True,
+                    "result": result,
+                }
+            else:
+                response = {
+                    "request_id": request_id,
+                    "action": "get_order_status",
+                    "success": False,
+                    "error_code": "ORDER_NOT_FOUND",
+                    "error": f"Order {order_id} not found",
+                }
+
+            await websocket.send_text(json.dumps(response))
+        except Exception as exc:  # pragma: no cover - env dependent
+            logger.error(
+                "Get order status failed",
+                exchange=exchange,
+                order_id=order_id,
+                error=str(exc),
+                request_id=request_id,
+            )
+            await self.send_error(
+                websocket, request_id, "CACHE_ERROR", "Failed to retrieve order status"
+            )
+
+    async def handle_get_queue_length(
+        self,
+        websocket: WebSocket,
+        request_id: str,
+        params: dict[str, Any],
+        connection_id: str,
+    ) -> None:
+        exchange = params.get("exchange")
+        if not exchange:
+            await self.send_error(
+                websocket, request_id, "INVALID_PARAMS", "exchange parameter required"
+            )
+            return
+
+        logger.info(
+            "Get queue length started",
+            exchange=exchange,
+            request_id=request_id,
+            connection_id=connection_id,
+        )
+
+        try:
+            from fullon_cache import OrdersCache  # type: ignore
+
+            async with OrdersCache() as cache:  # type: ignore[call-arg]
+                # Use number of orders for the exchange as a proxy for queue length
+                orders = await cache.get_orders(str(exchange))
+                queue_length = len(orders or [])
+
+            response = {
+                "request_id": request_id,
+                "action": "get_queue_length",
+                "success": True,
+                "result": {
+                    "exchange": str(exchange),
+                    "queue_length": queue_length,
+                    "timestamp": time.time(),
+                },
+            }
+            await websocket.send_text(json.dumps(response))
+        except Exception as exc:  # pragma: no cover - env dependent
+            logger.error(
+                "Get queue length failed", exchange=exchange, error=str(exc)
+            )
+            await self.send_error(
+                websocket, request_id, "CACHE_ERROR", "Failed to retrieve queue length"
+            )
+
+    async def handle_stream_order_queue(
+        self,
+        websocket: WebSocket,
+        request_id: str,
+        params: dict[str, Any],
+        connection_id: str,
+    ) -> None:
+        exchange = params.get("exchange")
+        if not exchange:
+            await self.send_error(
+                websocket, request_id, "INVALID_PARAMS", "exchange parameter required"
+            )
+            return
+
+        stream_key = f"{connection_id}:{request_id}"
+        try:
+            task = asyncio.create_task(
+                self._stream_queue_length(websocket, request_id, str(exchange), stream_key)
+            )
+            self.streaming_tasks[stream_key] = task
+
+            confirmation = {
+                "request_id": request_id,
+                "action": "stream_order_queue",
+                "success": True,
+                "message": f"Streaming started for {exchange}",
+                "stream_key": stream_key,
+            }
+            await websocket.send_text(json.dumps(confirmation))
+        except Exception as exc:  # pragma: no cover - env dependent
+            logger.error(
+                "Order queue streaming initialization failed",
+                exchange=exchange,
+                error=str(exc),
+                stream_key=stream_key,
+            )
+            await self.send_error(
+                websocket, request_id, "INTERNAL_ERROR", "Failed to start queue stream"
+            )
+
+    async def _stream_queue_length(
+        self, websocket: WebSocket, request_id: str, exchange: str, stream_key: str
+    ) -> None:
+        last_len: int | None = None
+        try:
+            from fullon_cache import OrdersCache  # type: ignore
+
+            async with OrdersCache() as cache:  # type: ignore[call-arg]
+                while True:
+                    try:
+                        orders = await cache.get_orders(exchange)
+                        qlen = len(orders or [])
+                    except Exception:
+                        qlen = last_len if last_len is not None else 0
+
+                    if qlen != last_len:
+                        last_len = qlen
+                        msg = {
+                            "request_id": request_id,
+                            "action": "queue_update",
+                            "result": {
+                                "stream_key": stream_key,
+                                "exchange": exchange,
+                                "queue_length": qlen,
+                                "timestamp": time.time(),
+                            },
+                        }
+                        await websocket.send_text(json.dumps(msg))
+
+                    await asyncio.sleep(0.5)
+        except asyncio.CancelledError:  # pragma: no cover - cancellation timing
+            logger.info("Order queue streaming cancelled", stream_key=stream_key)
+        except Exception as exc:  # pragma: no cover - env dependent
+            logger.error("Order queue streaming error", error=str(exc), stream_key=stream_key)
+
+    async def cleanup_connection(self, connection_id: str) -> None:
+        # Cancel and remove all streaming tasks for this connection
+        to_cancel = [
+            k for k in self.streaming_tasks.keys() if k.startswith(f"{connection_id}:")
+        ]
+        for key in to_cancel:
+            task = self.streaming_tasks.pop(key, None)
+            if task and not task.done():
+                task.cancel()
+        self.active_connections.pop(connection_id, None)
+

--- a/src/fullon_cache_api/main.py
+++ b/src/fullon_cache_api/main.py
@@ -12,6 +12,7 @@ from fullon_log import get_component_logger  # type: ignore
 
 
 from .routers.accounts import router as accounts_router
+from .routers.orders import router as orders_router
 from .routers.tickers import router as tickers_router
 from .routers.websocket import router as ws_router
 
@@ -22,6 +23,7 @@ def create_app() -> FastAPI:
     app = FastAPI(title="fullon_cache_api", docs_url=None, redoc_url=None)
     app.include_router(ws_router)
     app.include_router(tickers_router)
+    app.include_router(orders_router)
     app.include_router(accounts_router)
     logger.info("FastAPI WebSocket app created")
     return app

--- a/src/fullon_cache_api/routers/orders.py
+++ b/src/fullon_cache_api/routers/orders.py
@@ -1,0 +1,16 @@
+"""
+FastAPI router providing the orders WebSocket endpoint.
+"""
+
+from fastapi import APIRouter, WebSocket
+
+from ..handlers.order_handler import OrdersWebSocketHandler
+
+router = APIRouter()
+orders_handler = OrdersWebSocketHandler()
+
+
+@router.websocket("/ws/orders/{connection_id}")
+async def orders_websocket_endpoint(websocket: WebSocket, connection_id: str) -> None:
+    await orders_handler.handle_connection(websocket, connection_id)
+

--- a/tests/factories/order.py
+++ b/tests/factories/order.py
@@ -1,0 +1,64 @@
+"""Order factory for REAL Redis testing (NO MOCKS)."""
+
+import time
+import uuid
+from decimal import Decimal
+
+try:  # type: ignore
+    from fullon_orm.models import Order  # type: ignore
+except Exception:  # pragma: no cover - test env dependent
+    Order = object  # type: ignore
+
+
+class OrderFactory:
+    """Create realistic order data for REAL Redis cache testing."""
+
+    def __init__(self) -> None:
+        self.counter = 0
+
+    def create(
+        self,
+        symbol: str = "BTC/USDT",
+        exchange: str = "binance",
+        side: str = "buy",
+        amount: float = 1.0,
+        price: float = 50000.0,
+        **kwargs,
+    ):
+        """Create realistic order with proper calculations."""
+        self.counter += 1
+        order_id = kwargs.get("order_id", f"ORD_{uuid.uuid4().hex[:8]}")
+        filled = kwargs.get("filled", 0.0)
+        remaining = amount - float(filled)
+
+        if Order is object:  # pragma: no cover - missing ORM
+            # Fallback minimal structure for environments without fullon_orm
+            return {
+                "ex_order_id": order_id,
+                "symbol": symbol,
+                "exchange": exchange,
+                "side": side,
+                "volume": float(amount),
+                "price": float(price),
+                "final_volume": float(filled) if filled else None,
+                "remaining": float(remaining),
+                "status": kwargs.get("status", "open"),
+                "order_type": kwargs.get("order_type", "limit"),
+                "timestamp": kwargs.get("timestamp", time.time()),
+            }
+
+        o = Order()  # type: ignore[call-arg]
+        # Common/exchange identifiers
+        setattr(o, "ex_order_id", order_id)
+        setattr(o, "exchange", exchange)
+        # Core order data
+        setattr(o, "symbol", symbol)
+        setattr(o, "side", side)
+        setattr(o, "volume", float(amount))
+        setattr(o, "price", float(price))
+        setattr(o, "final_volume", float(filled) if filled else None)
+        setattr(o, "status", kwargs.get("status", "open"))
+        setattr(o, "order_type", kwargs.get("order_type", "limit"))
+        setattr(o, "timestamp", kwargs.get("timestamp", time.time()))
+        return o
+

--- a/tests/integration/test_orders_websocket_real.py
+++ b/tests/integration/test_orders_websocket_real.py
@@ -1,0 +1,185 @@
+"""Integration tests for orders WebSocket with REAL Redis (no mocks)."""
+
+import asyncio
+import json
+import uuid
+
+import pytest
+from fullon_cache_api.main import create_app
+from starlette.testclient import TestClient
+
+pytestmark = [pytest.mark.integration, pytest.mark.redis]
+
+
+def _flush_db():
+    try:
+        from fullon_cache import BaseCache  # type: ignore
+
+        async def _do():
+            cache = BaseCache()
+            async with cache._redis_context() as redis:
+                await redis.flushdb()
+            await cache.close()
+
+        asyncio.get_event_loop().run_until_complete(_do())
+    except Exception:
+        # Best effort cleanup; tests still run if flush not possible
+        pass
+
+
+def test_get_order_status_not_found_real_redis():
+    app = create_app()
+    client = TestClient(app)
+    _flush_db()
+
+    with client.websocket_connect("/ws/orders/not_found") as ws:
+        request = {
+            "action": "get_order_status",
+            "request_id": "not_found",
+            "params": {
+                "exchange": "binance",
+                "order_id": f"ORD_{uuid.uuid4().hex[:6]}",
+            },
+        }
+        ws.send_text(json.dumps(request))
+        response = json.loads(ws.receive_text())
+
+        assert response["success"] is False
+        assert response["error_code"] == "ORDER_NOT_FOUND"
+
+
+def test_get_order_status_real_redis():
+    try:
+        from fullon_cache import OrdersCache  # type: ignore
+        from tests.factories.order import OrderFactory
+    except Exception:
+        pytest.skip("fullon_cache not available in environment")
+
+    app = create_app()
+    client = TestClient(app)
+    _flush_db()
+
+    exchange = "binance"
+    order_id = f"ORD_{uuid.uuid4().hex[:6]}"
+    factory = OrderFactory()
+
+    async def _seed():
+        cache = OrdersCache()
+        try:
+            order = factory.create(order_id=order_id, exchange=exchange)
+            await cache.save_order_data(exchange, order)
+        finally:
+            await cache._cache.close()
+
+    asyncio.get_event_loop().run_until_complete(_seed())
+
+    with client.websocket_connect("/ws/orders/test_client") as ws:
+        request = {
+            "action": "get_order_status",
+            "request_id": "req1",
+            "params": {"exchange": exchange, "order_id": order_id},
+        }
+        ws.send_text(json.dumps(request))
+        response = json.loads(ws.receive_text())
+
+        assert response["success"] is True
+        assert response["result"]["order_id"] == order_id
+        assert response["result"]["exchange"] == exchange
+        assert response["result"]["symbol"] is not None
+
+
+def test_get_queue_length_real_redis():
+    try:
+        from fullon_cache import OrdersCache  # type: ignore
+        from tests.factories.order import OrderFactory
+    except Exception:
+        pytest.skip("fullon_cache not available in environment")
+
+    app = create_app()
+    client = TestClient(app)
+    _flush_db()
+
+    exchange = "kraken"
+    factory = OrderFactory()
+
+    async def _seed(n: int = 3):
+        cache = OrdersCache()
+        try:
+            for _ in range(n):
+                order = factory.create(exchange=exchange)
+                await cache.save_order_data(exchange, order)
+        finally:
+            await cache._cache.close()
+
+    asyncio.get_event_loop().run_until_complete(_seed(3))
+
+    with client.websocket_connect("/ws/orders/q_test") as ws:
+        request = {
+            "action": "get_queue_length",
+            "request_id": "ql1",
+            "params": {"exchange": exchange},
+        }
+        ws.send_text(json.dumps(request))
+        response = json.loads(ws.receive_text())
+
+        assert response["success"] is True
+        assert response["result"]["exchange"] == exchange
+        assert isinstance(response["result"]["queue_length"], int)
+        assert response["result"]["queue_length"] >= 3
+
+
+def test_stream_order_queue_real_redis():
+    try:
+        from fullon_cache import OrdersCache  # type: ignore
+        from tests.factories.order import OrderFactory
+    except Exception:
+        pytest.skip("fullon_cache not available in environment")
+
+    app = create_app()
+    client = TestClient(app)
+    _flush_db()
+
+    exchange = "binance"
+    factory = OrderFactory()
+
+    with client.websocket_connect("/ws/orders/stream_test") as ws:
+        # Start stream
+        request = {
+            "action": "stream_order_queue",
+            "request_id": "stream1",
+            "params": {"exchange": exchange},
+        }
+        ws.send_text(json.dumps(request))
+
+        # Expect confirmation first
+        conf = json.loads(ws.receive_text())
+        assert conf["success"] is True
+        assert conf["action"] == "stream_order_queue"
+
+        # Mutate data to trigger queue length change
+        async def _update():
+            cache = OrdersCache()
+            try:
+                await asyncio.sleep(0.6)
+                # Insert a few orders to increase count
+                for _ in range(2):
+                    order = factory.create(exchange=exchange)
+                    await cache.save_order_data(exchange, order)
+            finally:
+                await cache._cache.close()
+
+        loop = asyncio.get_event_loop()
+        loop.create_task(_update())
+
+        updates = []
+        # Read up to 5 messages looking for a queue_update
+        for _ in range(5):
+            msg = json.loads(ws.receive_text())
+            if msg.get("action") == "queue_update":
+                updates.append(msg)
+                break
+
+        assert len(updates) >= 1
+        assert updates[0]["result"]["exchange"] == exchange
+        assert isinstance(updates[0]["result"]["queue_length"], int)
+


### PR DESCRIPTION
This implements the Orders WebSocket handler, router wiring, real Redis integration tests and example client.\n\n- Handlers: get_order_status, get_queue_length, stream_order_queue\n- Router: /ws/orders/{connection_id}\n- Tests: tests/integration/test_orders_websocket_real.py (REAL Redis, no mocks)\n- Factory: tests/factories/order.py\n- Example: examples/orders_websocket_client.py\n\nCloses #7.