### PR TITLE
feat: Bots WebSocket handler + real Redis tests (closes #8)

### DIFF
--- a/examples/bots_websocket_client.py
+++ b/examples/bots_websocket_client.py
@@ -1,0 +1,45 @@
+"""Minimal example client for Bots WebSocket API.
+
+Usage:
+    poetry run python examples/bots_websocket_client.py
+"""
+
+import asyncio
+import json
+
+import websockets
+
+
+async def main() -> None:
+    uri = "ws://127.0.0.1:8000/ws/bots/example"
+    async with websockets.connect(uri) as ws:
+        # Query blocking status
+        await ws.send(
+            json.dumps(
+                {
+                    "action": "is_blocked",
+                    "request_id": "blk1",
+                    "params": {"exchange": "binance", "symbol": "BTC/USDT"},
+                }
+            )
+        )
+        print("is_blocked:", await ws.recv())
+
+        # Start stream (all bots)
+        await ws.send(
+            json.dumps(
+                {
+                    "action": "stream_bot_status",
+                    "request_id": "s1",
+                    "params": {},
+                }
+            )
+        )
+        # Print a couple of updates
+        for _ in range(2):
+            print("update:", await ws.recv())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/src/fullon_cache_api/handlers/bot_handler.py
+++ b/src/fullon_cache_api/handlers/bot_handler.py
@@ -1,0 +1,327 @@
+"""
+Bot WebSocket handler implementing read-only bot coordination/status operations.
+
+Implements:
+- get_bot_status: fetch a bot status snapshot
+- is_blocked: check if an exchange/symbol is blocked and by whom
+- get_bots: fetch all bots status
+- stream_bot_status: real-time bot status updates (polling, async only)
+
+Design constraints:
+- Read-only operations only
+- Uses fullon_log for structured logging
+- Uses fullon_cache BotCache sessions with async context mgmt
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+
+from fastapi import WebSocket, WebSocketDisconnect
+from fullon_log import get_component_logger  # type: ignore
+
+
+logger = get_component_logger("fullon.api.cache.bots")
+
+
+class BotWebSocketHandler:
+    def __init__(self) -> None:
+        self.active_connections: dict[str, WebSocket] = {}
+        self.streaming_tasks: dict[str, asyncio.Task[Any]] = {}
+
+    async def handle_connection(self, websocket: WebSocket, connection_id: str) -> None:
+        await websocket.accept()
+        self.active_connections[connection_id] = websocket
+        logger.info(
+            "Bot WebSocket connected", connection_id=connection_id, handler="bots"
+        )
+
+        try:
+            while True:
+                message = await websocket.receive_text()
+                await self.route_bot_message(websocket, message, connection_id)
+        except WebSocketDisconnect:
+            logger.info(
+                "Bot WebSocket disconnected",
+                connection_id=connection_id,
+                handler="bots",
+            )
+        finally:
+            await self.cleanup_connection(connection_id)
+
+    async def route_bot_message(
+        self, websocket: WebSocket, message: str, connection_id: str
+    ) -> None:
+        try:
+            data = json.loads(message)
+        except json.JSONDecodeError:
+            await self.send_error(
+                websocket, None, "MALFORMED_MESSAGE", "Malformed JSON message"
+            )
+            return
+
+        action = data.get("action")
+        request_id = data.get("request_id")
+        params = data.get("params", {}) or {}
+
+        if action == "get_bot_status":
+            await self.handle_get_bot_status(
+                websocket, request_id, params, connection_id
+            )
+        elif action == "is_blocked":
+            await self.handle_is_blocked(websocket, request_id, params, connection_id)
+        elif action == "get_bots":
+            await self.handle_get_bots(websocket, request_id, params, connection_id)
+        elif action == "stream_bot_status":
+            await self.handle_stream_bot_status(
+                websocket, request_id, params, connection_id
+            )
+        else:
+            await self.send_error(
+                websocket,
+                request_id,
+                "INVALID_OPERATION",
+                f"Operation '{action}' not implemented",
+            )
+
+    async def send_error(
+        self, websocket: WebSocket, request_id: str | None, code: str, message: str
+    ) -> None:
+        payload = {
+            "request_id": request_id,
+            "success": False,
+            "error_code": code,
+            "error": message,
+        }
+        await websocket.send_text(json.dumps(payload))
+
+    async def handle_get_bot_status(
+        self,
+        websocket: WebSocket,
+        request_id: str,
+        params: dict[str, Any],
+        connection_id: str,
+    ) -> None:
+        bot_id = params.get("bot_id")
+        if not bot_id:
+            await self.send_error(
+                websocket, request_id, "INVALID_PARAMS", "bot_id parameter required"
+            )
+            return
+
+        logger.info(
+            "Get bot status started",
+            bot_id=bot_id,
+            request_id=request_id,
+            connection_id=connection_id,
+        )
+
+        try:
+            from fullon_cache import BotCache  # type: ignore
+
+            async with BotCache() as cache:  # type: ignore[call-arg]
+                bots = await cache.get_bots()
+                data = bots.get(str(bot_id), None) if bots else None
+
+            if data:
+                # Attempt to normalize a few top-level fields if present
+                # Derive status from first feed if not explicitly set
+                status = None
+                if isinstance(data, dict):
+                    # Look for nested feed dicts
+                    for feed in data.values():
+                        if isinstance(feed, dict) and "status" in feed:
+                            status = feed.get("status")
+                            break
+                result = {
+                    "bot_id": str(bot_id),
+                    "status": status or "unknown",
+                    "data": data,
+                    "timestamp": time.time(),
+                }
+                response = {
+                    "request_id": request_id,
+                    "action": "get_bot_status",
+                    "success": True,
+                    "result": result,
+                }
+            else:
+                response = {
+                    "request_id": request_id,
+                    "action": "get_bot_status",
+                    "success": False,
+                    "error_code": "BOT_NOT_FOUND",
+                    "error": f"Bot {bot_id} not found",
+                }
+
+            await websocket.send_text(json.dumps(response))
+        except Exception as exc:  # pragma: no cover - env dependent
+            logger.error("Get bot status failed", bot_id=bot_id, error=str(exc))
+            await self.send_error(
+                websocket, request_id, "CACHE_ERROR", "Failed to retrieve bot status"
+            )
+
+    async def handle_is_blocked(
+        self,
+        websocket: WebSocket,
+        request_id: str,
+        params: dict[str, Any],
+        connection_id: str,
+    ) -> None:
+        exchange = params.get("exchange")
+        symbol = params.get("symbol")
+        if not exchange or not symbol:
+            await self.send_error(
+                websocket,
+                request_id,
+                "INVALID_PARAMS",
+                "exchange and symbol parameters required",
+            )
+            return
+
+        logger.info(
+            "Is blocked check started",
+            exchange=exchange,
+            symbol=symbol,
+            request_id=request_id,
+            connection_id=connection_id,
+        )
+
+        try:
+            from fullon_cache import BotCache  # type: ignore
+
+            async with BotCache() as cache:  # type: ignore[call-arg]
+                blocked_by = await cache.is_blocked(str(exchange), str(symbol))
+            is_blocked = bool(blocked_by)
+            response = {
+                "request_id": request_id,
+                "action": "is_blocked",
+                "success": True,
+                "result": {
+                    "exchange": str(exchange),
+                    "symbol": str(symbol),
+                    "is_blocked": is_blocked,
+                    "blocked_by": blocked_by or None,
+                    "timestamp": time.time(),
+                },
+            }
+            await websocket.send_text(json.dumps(response))
+        except Exception as exc:  # pragma: no cover - env dependent
+            logger.error(
+                "Is blocked check failed", exchange=exchange, symbol=symbol, error=str(exc)
+            )
+            await self.send_error(
+                websocket, request_id, "CACHE_ERROR", "Failed to query blocking status"
+            )
+
+    async def handle_get_bots(
+        self,
+        websocket: WebSocket,
+        request_id: str,
+        params: dict[str, Any],
+        connection_id: str,
+    ) -> None:
+        logger.info("Get bots started", request_id=request_id, connection_id=connection_id)
+        try:
+            from fullon_cache import BotCache  # type: ignore
+
+            async with BotCache() as cache:  # type: ignore[call-arg]
+                bots = await cache.get_bots()
+
+            response = {
+                "request_id": request_id,
+                "action": "get_bots",
+                "success": True,
+                "result": {"bots": bots or {}},
+            }
+            await websocket.send_text(json.dumps(response))
+        except Exception as exc:  # pragma: no cover - env dependent
+            logger.error("Get bots failed", error=str(exc))
+            await self.send_error(
+                websocket, request_id, "CACHE_ERROR", "Failed to retrieve bots"
+            )
+
+    async def handle_stream_bot_status(
+        self,
+        websocket: WebSocket,
+        request_id: str,
+        params: dict[str, Any],
+        connection_id: str,
+    ) -> None:
+        # Optional filter: single bot_id
+        bot_id = params.get("bot_id")
+        stream_key = f"{connection_id}:{request_id}"
+        try:
+            task = asyncio.create_task(
+                self._stream_bot_updates(websocket, request_id, bot_id, stream_key)
+            )
+            self.streaming_tasks[stream_key] = task
+
+            confirmation = {
+                "request_id": request_id,
+                "action": "stream_bot_status",
+                "success": True,
+                "message": (
+                    f"Streaming started for bot {bot_id}" if bot_id else "Streaming started"
+                ),
+                "stream_key": stream_key,
+            }
+            await websocket.send_text(json.dumps(confirmation))
+        except Exception as exc:  # pragma: no cover - env dependent
+            logger.error(
+                "Bot streaming initialization failed", error=str(exc), stream_key=stream_key
+            )
+            await self.send_error(
+                websocket, request_id, "INTERNAL_ERROR", "Failed to start bot streaming"
+            )
+
+    async def _stream_bot_updates(
+        self, websocket: WebSocket, request_id: str, bot_id: str | None, stream_key: str
+    ) -> None:
+        last_snapshot: dict[str, Any] | None = None
+        try:
+            from fullon_cache import BotCache  # type: ignore
+
+            async with BotCache() as cache:  # type: ignore[call-arg]
+                while True:
+                    try:
+                        bots = await cache.get_bots()
+                        snapshot = bots or {}
+                        if bot_id:
+                            snapshot = {bot_id: snapshot.get(bot_id)} if bot_id in snapshot else {}
+                    except Exception:
+                        snapshot = last_snapshot or {}
+
+                    if snapshot != last_snapshot:
+                        last_snapshot = snapshot
+                        msg = {
+                            "request_id": request_id,
+                            "action": "bot_update",
+                            "result": {
+                                "stream_key": stream_key,
+                                "bots": snapshot,
+                                "timestamp": time.time(),
+                            },
+                        }
+                        await websocket.send_text(json.dumps(msg))
+
+                    await asyncio.sleep(0.5)
+        except asyncio.CancelledError:  # pragma: no cover - cancellation timing
+            logger.info("Bot streaming cancelled", stream_key=stream_key)
+        except Exception as exc:  # pragma: no cover - env dependent
+            logger.error("Bot streaming error", error=str(exc), stream_key=stream_key)
+
+    async def cleanup_connection(self, connection_id: str) -> None:
+        # Cancel and remove all streaming tasks for this connection
+        to_cancel = [
+            k for k in self.streaming_tasks.keys() if k.startswith(f"{connection_id}:")
+        ]
+        for key in to_cancel:
+            task = self.streaming_tasks.pop(key, None)
+            if task and not task.done():
+                task.cancel()
+        self.active_connections.pop(connection_id, None)
+

--- a/src/fullon_cache_api/main.py
+++ b/src/fullon_cache_api/main.py
@@ -12,6 +12,7 @@ from fullon_log import get_component_logger  # type: ignore
 
 
 from .routers.accounts import router as accounts_router
+from .routers.bots import router as bots_router
 from .routers.orders import router as orders_router
 from .routers.tickers import router as tickers_router
 from .routers.websocket import router as ws_router
@@ -23,6 +24,7 @@ def create_app() -> FastAPI:
     app = FastAPI(title="fullon_cache_api", docs_url=None, redoc_url=None)
     app.include_router(ws_router)
     app.include_router(tickers_router)
+    app.include_router(bots_router)
     app.include_router(orders_router)
     app.include_router(accounts_router)
     logger.info("FastAPI WebSocket app created")

--- a/src/fullon_cache_api/routers/bots.py
+++ b/src/fullon_cache_api/routers/bots.py
@@ -1,0 +1,16 @@
+"""
+FastAPI router providing the bots WebSocket endpoint.
+"""
+
+from fastapi import APIRouter, WebSocket
+
+from ..handlers.bot_handler import BotWebSocketHandler
+
+router = APIRouter()
+bot_handler = BotWebSocketHandler()
+
+
+@router.websocket("/ws/bots/{connection_id}")
+async def bots_websocket_endpoint(websocket: WebSocket, connection_id: str) -> None:
+    await bot_handler.handle_connection(websocket, connection_id)
+

--- a/tests/integration/test_bots_websocket_real.py
+++ b/tests/integration/test_bots_websocket_real.py
@@ -1,0 +1,186 @@
+"""Integration tests for bots WebSocket with REAL Redis (no mocks)."""
+
+import asyncio
+import json
+
+import pytest
+from fullon_cache_api.main import create_app
+from starlette.testclient import TestClient
+
+pytestmark = [pytest.mark.integration, pytest.mark.redis]
+
+
+def _flush_db():
+    try:
+        from fullon_cache import BaseCache  # type: ignore
+
+        async def _do():
+            cache = BaseCache()
+            async with cache._redis_context() as redis:
+                await redis.flushdb()
+            await cache.close()
+
+        asyncio.get_event_loop().run_until_complete(_do())
+    except Exception:
+        # Best effort cleanup; tests still run if flush not possible
+        pass
+
+
+def test_get_bot_status_real_redis():
+    try:
+        from fullon_cache import BotCache  # type: ignore
+    except Exception:
+        pytest.skip("fullon_cache not available in environment")
+
+    app = create_app()
+    client = TestClient(app)
+    _flush_db()
+
+    async def _seed():
+        cache = BotCache()
+        try:
+            # Bot status is stored via update_bot(bot_id, data)
+            await cache.update_bot("BOT_001", {"feed_1": {"status": "active", "symbol": "BTC/USDT"}})
+        finally:
+            await cache._cache.close()
+
+    asyncio.get_event_loop().run_until_complete(_seed())
+
+    with client.websocket_connect("/ws/bots/test") as ws:
+        request = {
+            "action": "get_bot_status",
+            "request_id": "bot1",
+            "params": {"bot_id": "BOT_001"},
+        }
+        ws.send_text(json.dumps(request))
+        response = json.loads(ws.receive_text())
+
+        assert response["success"] is True
+        assert response["result"]["bot_id"] == "BOT_001"
+        assert response["result"]["status"] in ("active", "unknown")
+        assert "data" in response["result"]
+
+
+def test_is_blocked_real_redis():
+    try:
+        from fullon_cache import BotCache  # type: ignore
+    except Exception:
+        pytest.skip("fullon_cache not available in environment")
+
+    app = create_app()
+    client = TestClient(app)
+    _flush_db()
+
+    async def _seed():
+        cache = BotCache()
+        try:
+            await cache.block_exchange("binance", "BTC/USDT", "BOT_001")
+        finally:
+            await cache._cache.close()
+
+    asyncio.get_event_loop().run_until_complete(_seed())
+
+    with client.websocket_connect("/ws/bots/blk") as ws:
+        request = {
+            "action": "is_blocked",
+            "request_id": "blk1",
+            "params": {"exchange": "binance", "symbol": "BTC/USDT"},
+        }
+        ws.send_text(json.dumps(request))
+        response = json.loads(ws.receive_text())
+
+        assert response["success"] is True
+        assert response["result"]["exchange"] == "binance"
+        assert response["result"]["symbol"] == "BTC/USDT"
+        assert response["result"]["is_blocked"] is True
+        assert response["result"]["blocked_by"] == "BOT_001"
+
+
+def test_get_bots_real_redis():
+    try:
+        from fullon_cache import BotCache  # type: ignore
+    except Exception:
+        pytest.skip("fullon_cache not available in environment")
+
+    app = create_app()
+    client = TestClient(app)
+    _flush_db()
+
+    async def _seed():
+        cache = BotCache()
+        try:
+            await cache.update_bot("BOT_A", {"feed": {"status": "running"}})
+            await cache.update_bot("BOT_B", {"feed": {"status": "stopped"}})
+        finally:
+            await cache._cache.close()
+
+    asyncio.get_event_loop().run_until_complete(_seed())
+
+    with client.websocket_connect("/ws/bots/get") as ws:
+        request = {"action": "get_bots", "request_id": "gb1", "params": {}}
+        ws.send_text(json.dumps(request))
+        response = json.loads(ws.receive_text())
+
+        assert response["success"] is True
+        bots = response["result"]["bots"]
+        assert isinstance(bots, dict)
+        assert "BOT_A" in bots and "BOT_B" in bots
+
+
+def test_stream_bot_status_real_redis():
+    try:
+        from fullon_cache import BotCache  # type: ignore
+    except Exception:
+        pytest.skip("fullon_cache not available in environment")
+
+    app = create_app()
+    client = TestClient(app)
+    _flush_db()
+
+    async def _seed():
+        cache = BotCache()
+        try:
+            await cache.update_bot("BOT_S", {"feed": {"status": "idle"}})
+        finally:
+            await cache._cache.close()
+
+    asyncio.get_event_loop().run_until_complete(_seed())
+
+    with client.websocket_connect("/ws/bots/stream") as ws:
+        # Start stream for specific bot
+        request = {
+            "action": "stream_bot_status",
+            "request_id": "s1",
+            "params": {"bot_id": "BOT_S"},
+        }
+        ws.send_text(json.dumps(request))
+
+        # Expect confirmation
+        conf = json.loads(ws.receive_text())
+        assert conf["success"] is True
+        assert conf["action"] == "stream_bot_status"
+
+        # Modify bot to trigger update
+        async def _update():
+            cache = BotCache()
+            try:
+                await asyncio.sleep(0.6)
+                await cache.update_bot("BOT_S", {"feed": {"status": "active"}})
+            finally:
+                await cache._cache.close()
+
+        loop = asyncio.get_event_loop()
+        loop.create_task(_update())
+
+        # Read a few messages to find an update
+        updates = []
+        for _ in range(5):
+            msg = json.loads(ws.receive_text())
+            if msg.get("action") == "bot_update":
+                bots = msg["result"]["bots"]
+                if "BOT_S" in bots:
+                    updates.append(msg)
+                    break
+
+        assert len(updates) >= 1
+


### PR DESCRIPTION
This implements the Bots WebSocket handler and router with real Redis tests and a minimal example client.\n\n- Handlers: get_bot_status, is_blocked, get_bots, stream_bot_status\n- Router: /ws/bots/{connection_id}\n- Tests: tests/integration/test_bots_websocket_real.py (REAL Redis; no mocks)\n- Example: examples/bots_websocket_client.py\n\nCloses #8.