### PR TITLE
fix: accounts handler side detection + unit test update

### DIFF
--- a/src/fullon_cache_api/handlers/account_handler.py
+++ b/src/fullon_cache_api/handlers/account_handler.py
@@ -216,7 +216,9 @@ class AccountWebSocketHandler:
                     continue
 
                 volume = float(getattr(p, "volume", 0.0))
-                side = "long" if volume >= 0 else "short"
+                # Prefer explicit side from model; fallback to sign
+                side_attr = getattr(p, "side", None)
+                side = side_attr if side_attr in {"long", "short"} else ("long" if volume >= 0 else "short")
                 items.append(
                     {
                         "symbol": getattr(p, "symbol", None),
@@ -366,7 +368,8 @@ class AccountWebSocketHandler:
                 continue
 
             volume = float(getattr(p, "volume", 0.0))
-            side = "long" if volume >= 0 else "short"
+            side_attr = getattr(p, "side", None)
+            side = side_attr if side_attr in {"long", "short"} else ("long" if volume >= 0 else "short")
             msg = {
                 "request_id": request_id,
                 "action": "position_update",

--- a/tests/unit/test_accounts_handler_real.py
+++ b/tests/unit/test_accounts_handler_real.py
@@ -76,8 +76,9 @@ def test_get_positions_unit_real_redis():
         cache = AccountCache()
         try:
             positions = [
-                Position(symbol="BTC/USDT", volume=0.3, price=50000.0, ex_id="ex1"),
-                Position(symbol="ETH/USDT", volume=-1.2, price=3000.0, ex_id="ex1"),
+                Position(symbol="BTC/USDT", volume=0.3, price=50000.0, ex_id="ex1", side="long"),
+                # ORM disallows negative volume; use side='short' with positive volume
+                Position(symbol="ETH/USDT", volume=1.2, price=3000.0, ex_id="ex1", side="short"),
             ]
             await cache.upsert_positions(222, positions)
         finally:
@@ -100,4 +101,3 @@ def test_get_positions_unit_real_redis():
         assert response["result"]["count"] >= 2
         symbols = {p["symbol"] for p in response["result"]["positions"]}
         assert {"BTC/USDT", "ETH/USDT"}.issubset(symbols)
-


### PR DESCRIPTION
- Prefer Position.side when available; fallback to volume sign.\n- Update unit test to avoid negative volume (ORM forbids it).\n\nFixes failing test in tests/unit/test_accounts_handler_real.py.