### PR TITLE
feat(ohlcv): add TDD tests for OHLCV WebSocket handler (#10)

### DIFF
--- a/src/fullon_cache_api/handlers/ohlcv_handler.py
+++ b/src/fullon_cache_api/handlers/ohlcv_handler.py
@@ -1,0 +1,349 @@
+"""
+OHLCV WebSocket handler implementing read-only OHLCV operations.
+
+Implements:
+- get_latest_ohlcv_bars: fetch latest N OHLCV bars
+- stream_ohlcv: start real-time OHLCV updates via async iterator/polling
+
+Design constraints:
+- Read-only operations only
+- Uses fullon_log for structured logging
+- Uses fullon_cache OHLCVCache sessions with async context mgmt
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from fastapi import WebSocket, WebSocketDisconnect
+from fullon_log import get_component_logger  # type: ignore
+
+
+logger = get_component_logger("fullon.api.cache.ohlcv")
+
+
+class OHLCVWebSocketHandler:
+    def __init__(self) -> None:
+        self.active_connections: dict[str, WebSocket] = {}
+        self.streaming_tasks: dict[str, asyncio.Task[Any]] = {}
+
+    async def handle_connection(self, websocket: WebSocket, connection_id: str) -> None:
+        await websocket.accept()
+        self.active_connections[connection_id] = websocket
+        logger.info(
+            "OHLCV WebSocket connected", connection_id=connection_id, handler="ohlcv"
+        )
+
+        try:
+            while True:
+                message = await websocket.receive_text()
+                await self.route_ohlcv_message(websocket, message, connection_id)
+        except WebSocketDisconnect:
+            logger.info(
+                "OHLCV WebSocket disconnected",
+                connection_id=connection_id,
+                handler="ohlcv",
+            )
+        finally:
+            await self.cleanup_connection(connection_id)
+
+    async def route_ohlcv_message(
+        self, websocket: WebSocket, message: str, connection_id: str
+    ) -> None:
+        try:
+            data = json.loads(message)
+        except json.JSONDecodeError:
+            await self.send_error(
+                websocket, None, "MALFORMED_MESSAGE", "Malformed JSON message"
+            )
+            return
+
+        action = data.get("action")
+        request_id = data.get("request_id")
+        params = data.get("params", {}) or {}
+
+        if action == "get_latest_ohlcv_bars":
+            await self.handle_get_latest_ohlcv_bars(
+                websocket, request_id, params, connection_id
+            )
+        elif action == "stream_ohlcv":
+            await self.handle_stream_ohlcv(
+                websocket, request_id, params, connection_id
+            )
+        else:
+            await self.send_error(
+                websocket,
+                request_id,
+                "INVALID_OPERATION",
+                f"Operation '{action}' not implemented",
+            )
+
+    async def send_error(
+        self, websocket: WebSocket, request_id: str | None, code: str, message: str
+    ) -> None:
+        payload = {
+            "request_id": request_id,
+            "success": False,
+            "error_code": code,
+            "error": message,
+        }
+        await websocket.send_text(json.dumps(payload))
+
+    async def handle_get_latest_ohlcv_bars(
+        self,
+        websocket: WebSocket,
+        request_id: str,
+        params: dict[str, Any],
+        connection_id: str,
+    ) -> None:
+        symbol = params.get("symbol")
+        timeframe = params.get("timeframe")
+        count = int(params.get("count", 10))
+
+        if not symbol or not timeframe:
+            await self.send_error(
+                websocket,
+                request_id,
+                "INVALID_PARAMS",
+                "symbol and timeframe parameters required",
+            )
+            return
+
+        logger.info(
+            "Get latest OHLCV operation started",
+            symbol=symbol,
+            timeframe=timeframe,
+            count=count,
+            request_id=request_id,
+            connection_id=connection_id,
+        )
+
+        try:
+            try:
+                from fullon_cache import OHLCVCache  # type: ignore
+            except Exception:  # pragma: no cover - import path variant
+                from fullon_cache.ohlcv_cache import OHLCVCache  # type: ignore
+
+            async with OHLCVCache() as cache:  # type: ignore[call-arg]
+                bars: list[list[float]] | None = None
+
+                getter = getattr(cache, "get_latest_ohlcv_bars", None)
+                if callable(getter):
+                    try:
+                        bars = await getter(symbol, timeframe, count)  # type: ignore[misc]
+                    except TypeError:
+                        # Some implementations might use keywords
+                        bars = await getter(symbol=symbol, timeframe=timeframe, count=count)  # type: ignore[misc]
+                else:
+                    # Fallback: try to get all and slice
+                    get_all = getattr(cache, "get_ohlcv_bars", None)
+                    if callable(get_all):
+                        try:
+                            all_bars = await get_all(symbol, timeframe)  # type: ignore[misc]
+                        except TypeError:
+                            all_bars = await get_all(symbol=symbol, timeframe=timeframe)  # type: ignore[misc]
+                        bars = (all_bars or [])[-count:]
+
+            if bars and len(bars) > 0:
+                response = {
+                    "request_id": request_id,
+                    "action": "get_latest_ohlcv_bars",
+                    "success": True,
+                    "result": {
+                        "symbol": symbol,
+                        "timeframe": timeframe,
+                        "bars": bars,
+                    },
+                }
+                logger.info(
+                    "Get latest OHLCV operation completed",
+                    symbol=symbol,
+                    timeframe=timeframe,
+                    returned=len(bars),
+                    request_id=request_id,
+                )
+            else:
+                response = {
+                    "request_id": request_id,
+                    "action": "get_latest_ohlcv_bars",
+                    "success": False,
+                    "error_code": "OHLCV_NOT_FOUND",
+                    "error": f"OHLCV data not found for {symbol} {timeframe}",
+                }
+
+            await websocket.send_text(json.dumps(response))
+        except Exception as exc:  # pragma: no cover - env dependent
+            logger.error(
+                "Get latest OHLCV operation failed",
+                symbol=symbol,
+                timeframe=timeframe,
+                error=str(exc),
+                request_id=request_id,
+            )
+            await self.send_error(
+                websocket, request_id, "CACHE_ERROR", "Failed to retrieve OHLCV data"
+            )
+
+    async def handle_stream_ohlcv(
+        self,
+        websocket: WebSocket,
+        request_id: str,
+        params: dict[str, Any],
+        connection_id: str,
+    ) -> None:
+        symbol = params.get("symbol")
+        timeframe = params.get("timeframe")
+        if not symbol or not timeframe:
+            await self.send_error(
+                websocket, request_id, "INVALID_PARAMS", "symbol and timeframe required"
+            )
+            return
+
+        stream_key = f"{connection_id}:{request_id}"
+        try:
+            task = asyncio.create_task(
+                self._stream_ohlcv_updates(
+                    websocket, request_id, symbol, timeframe, stream_key
+                )
+            )
+            self.streaming_tasks[stream_key] = task
+
+            confirmation = {
+                "request_id": request_id,
+                "action": "stream_ohlcv",
+                "success": True,
+                "message": f"Streaming started for {symbol} {timeframe}",
+                "stream_key": stream_key,
+            }
+            await websocket.send_text(json.dumps(confirmation))
+        except Exception as exc:  # pragma: no cover - env dependent
+            logger.error(
+                "OHLCV streaming initialization failed",
+                symbol=symbol,
+                timeframe=timeframe,
+                error=str(exc),
+                stream_key=stream_key,
+            )
+            await self.send_error(
+                websocket, request_id, "INTERNAL_ERROR", "Failed to start OHLCV streaming"
+            )
+
+    async def _stream_ohlcv_updates(
+        self,
+        websocket: WebSocket,
+        request_id: str,
+        symbol: str,
+        timeframe: str,
+        stream_key: str,
+    ) -> None:
+        last_ts: float | None = None
+        try:
+            try:
+                from fullon_cache import OHLCVCache  # type: ignore
+            except Exception:  # pragma: no cover - import path variant
+                from fullon_cache.ohlcv_cache import OHLCVCache  # type: ignore
+
+            async with OHLCVCache() as cache:  # type: ignore[call-arg]
+                # Prefer a native iterator if available
+                stream_iter = getattr(cache, "stream_ohlcv_updates", None)
+                if callable(stream_iter):
+                    async for bar in stream_iter(symbol, timeframe):  # type: ignore[misc]
+                        # Expect bar format: [ts, o, h, l, c, v] or object with fields
+                        if isinstance(bar, (list, tuple)) and len(bar) >= 6:
+                            payload_bar = [
+                                float(bar[0]),
+                                float(bar[1]),
+                                float(bar[2]),
+                                float(bar[3]),
+                                float(bar[4]),
+                                float(bar[5]),
+                            ]
+                        else:
+                            # Object-like
+                            payload_bar = [
+                                float(getattr(bar, "timestamp", getattr(bar, "time", 0.0))),
+                                float(getattr(bar, "open", 0.0)),
+                                float(getattr(bar, "high", 0.0)),
+                                float(getattr(bar, "low", 0.0)),
+                                float(getattr(bar, "close", 0.0)),
+                                float(getattr(bar, "volume", 0.0)),
+                            ]
+
+                        msg = {
+                            "request_id": request_id,
+                            "action": "ohlcv_update",
+                            "result": {
+                                "stream_key": stream_key,
+                                "symbol": symbol,
+                                "timeframe": timeframe,
+                                "bar": payload_bar,
+                            },
+                        }
+                        await websocket.send_text(json.dumps(msg))
+                else:
+                    # Fallback: lightweight polling of the latest bar
+                    while True:
+                        try:
+                            getter = getattr(cache, "get_latest_ohlcv_bars", None)
+                            latest: list[list[float]] | None
+                            if callable(getter):
+                                try:
+                                    latest = await getter(symbol, timeframe, 1)  # type: ignore[misc]
+                                except TypeError:
+                                    latest = await getter(symbol=symbol, timeframe=timeframe, count=1)  # type: ignore[misc]
+                            else:
+                                get_all = getattr(cache, "get_ohlcv_bars", None)
+                                if callable(get_all):
+                                    try:
+                                        all_bars = await get_all(symbol, timeframe)  # type: ignore[misc]
+                                    except TypeError:
+                                        all_bars = await get_all(symbol=symbol, timeframe=timeframe)  # type: ignore[misc]
+                                    latest = (all_bars or [])[-1:]
+                                else:
+                                    latest = None
+                        except Exception:
+                            latest = None
+
+                        if latest:
+                            bar = latest[0]
+                            ts = float(bar[0]) if isinstance(bar, (list, tuple)) else None
+                            if ts is not None and ts != last_ts:
+                                msg = {
+                                    "request_id": request_id,
+                                    "action": "ohlcv_update",
+                                    "result": {
+                                        "stream_key": stream_key,
+                                        "symbol": symbol,
+                                        "timeframe": timeframe,
+                                        "bar": [
+                                            float(bar[0]),
+                                            float(bar[1]),
+                                            float(bar[2]),
+                                            float(bar[3]),
+                                            float(bar[4]),
+                                            float(bar[5]),
+                                        ],
+                                    },
+                                }
+                                await websocket.send_text(json.dumps(msg))
+                                last_ts = ts
+
+                        await asyncio.sleep(0.5)
+        except asyncio.CancelledError:  # pragma: no cover - cancellation timing
+            logger.info("OHLCV streaming cancelled", stream_key=stream_key)
+        except Exception as exc:  # pragma: no cover - env dependent
+            logger.error("OHLCV streaming error", error=str(exc), stream_key=stream_key)
+
+    async def cleanup_connection(self, connection_id: str) -> None:
+        # Cancel and remove all streaming tasks for this connection
+        to_cancel = [
+            k for k in self.streaming_tasks.keys() if k.startswith(f"{connection_id}:")
+        ]
+        for key in to_cancel:
+            task = self.streaming_tasks.pop(key, None)
+            if task and not task.done():
+                task.cancel()
+        self.active_connections.pop(connection_id, None)
+

--- a/src/fullon_cache_api/main.py
+++ b/src/fullon_cache_api/main.py
@@ -15,6 +15,7 @@ from .routers.accounts import router as accounts_router
 from .routers.bots import router as bots_router
 from .routers.orders import router as orders_router
 from .routers.trades import router as trades_router
+from .routers.ohlcv import router as ohlcv_router
 from .routers.tickers import router as tickers_router
 from .routers.websocket import router as ws_router
 
@@ -28,6 +29,7 @@ def create_app() -> FastAPI:
     app.include_router(bots_router)
     app.include_router(orders_router)
     app.include_router(trades_router)
+    app.include_router(ohlcv_router)
     app.include_router(accounts_router)
     logger.info("FastAPI WebSocket app created")
     return app

--- a/src/fullon_cache_api/routers/ohlcv.py
+++ b/src/fullon_cache_api/routers/ohlcv.py
@@ -1,0 +1,16 @@
+"""
+FastAPI router providing the OHLCV WebSocket endpoint.
+"""
+
+from fastapi import APIRouter, WebSocket
+
+from ..handlers.ohlcv_handler import OHLCVWebSocketHandler
+
+router = APIRouter()
+ohlcv_handler = OHLCVWebSocketHandler()
+
+
+@router.websocket("/ws/ohlcv/{connection_id}")
+async def ohlcv_websocket_endpoint(websocket: WebSocket, connection_id: str) -> None:
+    await ohlcv_handler.handle_connection(websocket, connection_id)
+

--- a/tests/integration/test_ohlcv_websocket_real.py
+++ b/tests/integration/test_ohlcv_websocket_real.py
@@ -1,0 +1,136 @@
+"""Integration tests for OHLCV WebSocket with REAL Redis (no mocks)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+import uuid
+
+import pytest
+from fullon_cache_api.main import create_app
+from starlette.testclient import TestClient
+
+pytestmark = [pytest.mark.integration, pytest.mark.redis]
+
+
+def _flush_db() -> None:
+    try:
+        from fullon_cache import BaseCache  # type: ignore
+
+        async def _do() -> None:
+            cache = BaseCache()
+            async with cache._redis_context() as redis:
+                await redis.flushdb()
+            await cache.close()
+
+        asyncio.get_event_loop().run_until_complete(_do())
+    except Exception:
+        # Best effort cleanup; tests still run if flush not possible
+        pass
+
+
+def _make_bars(start_ts: int, count: int = 10, base_price: float = 100.0) -> list[list[float]]:
+    bars: list[list[float]] = []
+    ts = start_ts
+    price = base_price
+    for i in range(count):
+        o = price
+        h = o * 1.01
+        l = o * 0.99
+        c = o * 1.002
+        v = 100 + i
+        bars.append([float(ts), float(o), float(h), float(l), float(c), float(v)])
+        ts += 60
+        price = c
+    return bars
+
+
+def test_get_latest_ohlcv_bars_real_redis() -> None:
+    try:
+        try:
+            from fullon_cache import OHLCVCache  # type: ignore
+        except Exception:
+            from fullon_cache.ohlcv_cache import OHLCVCache  # type: ignore
+    except Exception:
+        pytest.skip("fullon_cache not available in environment")
+
+    app = create_app()
+    client = TestClient(app)
+    _flush_db()
+
+    symbol = f"BTC/{uuid.uuid4().hex[:4]}USDT"
+    timeframe = "1m"
+
+    async def _seed() -> None:
+        cache = OHLCVCache()
+        try:
+            start = int(time.time()) - 60 * 50
+            bars = _make_bars(start, count=50, base_price=47000.0)
+            await cache.update_ohlcv_bars(symbol, timeframe, bars)
+        finally:
+            await cache._cache.close()
+
+    asyncio.get_event_loop().run_until_complete(_seed())
+
+    with client.websocket_connect("/ws/ohlcv/integration") as ws:
+        request = {
+            "action": "get_latest_ohlcv_bars",
+            "request_id": "req1",
+            "params": {"symbol": symbol, "timeframe": timeframe, "count": 20},
+        }
+        ws.send_text(json.dumps(request))
+        response = json.loads(ws.receive_text())
+
+        assert response["success"] is True
+        assert response["action"] == "get_latest_ohlcv_bars"
+        assert response["result"]["symbol"] == symbol
+        assert response["result"]["timeframe"] == timeframe
+        assert isinstance(response["result"]["bars"], list)
+        assert len(response["result"]["bars"]) == 20
+
+
+def test_stream_ohlcv_real_redis() -> None:
+    try:
+        try:
+            from fullon_cache import OHLCVCache  # type: ignore
+        except Exception:
+            from fullon_cache.ohlcv_cache import OHLCVCache  # type: ignore
+    except Exception:
+        pytest.skip("fullon_cache not available in environment")
+
+    app = create_app()
+    client = TestClient(app)
+    _flush_db()
+
+    symbol = f"ETH/{uuid.uuid4().hex[:4]}USDT"
+    timeframe = "1m"
+
+    async def _seed() -> None:
+        cache = OHLCVCache()
+        try:
+            start = int(time.time()) - 60 * 5
+            bars = _make_bars(start, count=5, base_price=3000.0)
+            await cache.update_ohlcv_bars(symbol, timeframe, bars)
+        finally:
+            await cache._cache.close()
+
+    asyncio.get_event_loop().run_until_complete(_seed())
+
+    with client.websocket_connect("/ws/ohlcv/stream_integration") as ws:
+        # Start stream
+        request = {
+            "action": "stream_ohlcv",
+            "request_id": "s1",
+            "params": {"symbol": symbol, "timeframe": timeframe},
+        }
+        ws.send_text(json.dumps(request))
+
+        # Expect confirmation
+        conf = json.loads(ws.receive_text())
+        assert conf["success"] is True
+        assert conf["action"] == "stream_ohlcv"
+
+        # Keep this integration test light: only validate stream setup (like trades stream test)
+        # Full update assertion is covered in the unit-ish test.
+

--- a/tests/unit/test_ohlcv_handler_real.py
+++ b/tests/unit/test_ohlcv_handler_real.py
@@ -1,0 +1,187 @@
+"""Unit-ish tests for OHLCV handler over WebSocket (real Redis)."""
+
+import asyncio
+import json
+import time
+import uuid
+
+import pytest
+from fullon_cache_api.main import create_app
+from starlette.testclient import TestClient
+
+pytestmark = [pytest.mark.redis]
+
+
+def _flush_db() -> None:
+    try:
+        from fullon_cache import BaseCache  # type: ignore
+
+        async def _do() -> None:
+            cache = BaseCache()
+            async with cache._redis_context() as redis:
+                await redis.flushdb()
+            await cache.close()
+
+        asyncio.get_event_loop().run_until_complete(_do())
+    except Exception:
+        # Best effort cleanup; tests still run if flush not possible
+        pass
+
+
+def _make_bars(start_ts: int, count: int = 10, base_price: float = 100.0) -> list[list[float]]:
+    bars: list[list[float]] = []
+    ts = start_ts
+    price = base_price
+    for i in range(count):
+        o = price
+        h = o * 1.01
+        l = o * 0.99
+        c = o * 1.002
+        v = 100 + i
+        bars.append([float(ts), float(o), float(h), float(l), float(c), float(v)])
+        ts += 60  # 1-minute spacing
+        price = c
+    return bars
+
+
+def test_get_latest_ohlcv_bars_unit_real_redis() -> None:
+    try:
+        try:
+            from fullon_cache import OHLCVCache  # type: ignore
+        except Exception:
+            from fullon_cache.ohlcv_cache import OHLCVCache  # type: ignore
+    except Exception:
+        pytest.skip("fullon_cache not available in environment")
+
+    app = create_app()
+    client = TestClient(app)
+    _flush_db()
+
+    symbol = f"BTC/{uuid.uuid4().hex[:4]}USDT"
+    timeframe = "1m"
+
+    async def _seed() -> None:
+        cache = OHLCVCache()
+        try:
+            start = int(time.time()) - 60 * 100
+            bars = _make_bars(start, count=50, base_price=47000.0)
+            await cache.update_ohlcv_bars(symbol, timeframe, bars)
+        finally:
+            await cache._cache.close()
+
+    asyncio.get_event_loop().run_until_complete(_seed())
+
+    with client.websocket_connect("/ws/ohlcv/unit") as ws:
+        request = {
+            "action": "get_latest_ohlcv_bars",
+            "request_id": "ohlcv1",
+            "params": {"symbol": symbol, "timeframe": timeframe, "count": 10},
+        }
+        ws.send_text(json.dumps(request))
+        response = json.loads(ws.receive_text())
+
+        assert response["success"] is True
+        assert response["action"] == "get_latest_ohlcv_bars"
+        result = response["result"]
+        assert result["symbol"] == symbol
+        assert result["timeframe"] == timeframe
+        assert isinstance(result["bars"], list)
+        assert len(result["bars"]) == 10
+        assert all(isinstance(b, list) and len(b) == 6 for b in result["bars"])
+
+
+def test_get_latest_ohlcv_bars_not_found_unit_real_redis() -> None:
+    try:
+        try:
+            from fullon_cache import OHLCVCache  # type: ignore  # noqa: F401
+        except Exception:
+            from fullon_cache.ohlcv_cache import OHLCVCache  # type: ignore  # noqa: F401
+    except Exception:
+        pytest.skip("fullon_cache not available in environment")
+
+    app = create_app()
+    client = TestClient(app)
+    _flush_db()
+
+    with client.websocket_connect("/ws/ohlcv/not_found") as ws:
+        request = {
+            "action": "get_latest_ohlcv_bars",
+            "request_id": "nf1",
+            "params": {"symbol": "BTC/USDT", "timeframe": "1m", "count": 5},
+        }
+        ws.send_text(json.dumps(request))
+        response = json.loads(ws.receive_text())
+
+        assert response["success"] is False
+        assert response["error_code"] in ("OHLCV_NOT_FOUND", "CACHE_MISS")
+
+
+def test_stream_ohlcv_unit_real_redis() -> None:
+    try:
+        try:
+            from fullon_cache import OHLCVCache  # type: ignore
+        except Exception:
+            from fullon_cache.ohlcv_cache import OHLCVCache  # type: ignore
+    except Exception:
+        pytest.skip("fullon_cache not available in environment")
+
+    app = create_app()
+    client = TestClient(app)
+    _flush_db()
+
+    symbol = f"ETH/{uuid.uuid4().hex[:4]}USDT"
+    timeframe = "1m"
+
+    async def _seed_initial() -> None:
+        cache = OHLCVCache()
+        try:
+            start = int(time.time()) - 60 * 5
+            bars = _make_bars(start, count=5, base_price=3000.0)
+            await cache.update_ohlcv_bars(symbol, timeframe, bars)
+        finally:
+            await cache._cache.close()
+
+    asyncio.get_event_loop().run_until_complete(_seed_initial())
+
+    with client.websocket_connect("/ws/ohlcv/stream_unit") as ws:
+        # Start stream
+        request = {
+            "action": "stream_ohlcv",
+            "request_id": "s1",
+            "params": {"symbol": symbol, "timeframe": timeframe},
+        }
+        ws.send_text(json.dumps(request))
+
+        # Expect confirmation
+        conf = json.loads(ws.receive_text())
+        assert conf["success"] is True
+        assert conf["action"] == "stream_ohlcv"
+
+        # Mutate data to trigger an update
+        async def _mutate() -> None:
+            cache = OHLCVCache()
+            try:
+                await asyncio.sleep(0.6)
+                # Append one new bar
+                start = int(time.time())
+                new_bars = _make_bars(start, count=1, base_price=3010.0)
+                await cache.update_ohlcv_bars(symbol, timeframe, new_bars)
+            finally:
+                await cache._cache.close()
+
+        loop = asyncio.get_event_loop()
+        loop.create_task(_mutate())
+
+        updates: list[dict] = []
+        for _ in range(6):
+            msg = json.loads(ws.receive_text())
+            if msg.get("action") == "ohlcv_update":
+                updates.append(msg)
+                break
+
+        assert len(updates) >= 1
+        upd = updates[0]["result"]
+        assert upd["symbol"] == symbol
+        assert upd["timeframe"] == timeframe
+        assert isinstance(upd["bar"], list) and len(upd["bar"]) == 6
+


### PR DESCRIPTION
This draft PR adds TDD-first tests for the OHLCV WebSocket handler, referencing #10.

- Unit-ish tests (real Redis):
  - get_latest_ohlcv_bars: success + not-found
  - stream_ohlcv: confirmation + update on mutation
- Integration tests (real Redis):
  - get_latest_ohlcv_bars: retrieval of N bars
  - stream_ohlcv: confirmation only (full updates covered in unit-ish tests)

Notes:
- Tests target  and actions  + .
- Deterministic seeding via .
- This is intentionally failing until the handler + router are implemented.

Next steps (to land in follow-up commits on this PR):
- Implement  and .
- Wire router in .
- Add minimal example client and README/docs updates.

Closes #10 (once implementation lands).